### PR TITLE
Make I/O calls async

### DIFF
--- a/custom_components/oura/sensor.py
+++ b/custom_components/oura/sensor.py
@@ -109,9 +109,8 @@ class OuraSleepSensor(entity.Entity):
     device_state_attributes: attributes of the sensor.
 
   Methods:
-    async_update: async version of update method.
+    async_update: updates sensor data.
     create_oauth_view: creates a view to manage OAuth setup.
-    update: updates sensor data.
   """
 
   def __init__(self, config, hass):
@@ -260,7 +259,7 @@ class OuraSleepSensor(entity.Entity):
 
     return sleep_dict
 
-  def update(self):
+  def _update(self):
     """Fetches new state data for the sensor."""
     sleep_dates = {
         date_name: self._get_date_by_name(date_name)
@@ -367,4 +366,4 @@ class OuraSleepSensor(entity.Entity):
 
   # Async wrappers.
   async def async_update(self):
-    await self._hass.async_add_job(self.update)
+    await self._hass.async_add_executor_job(self._update)

--- a/custom_components/oura/sensor.py
+++ b/custom_components/oura/sensor.py
@@ -74,9 +74,10 @@ async def setup(hass, config):
   return True
 
 
-def setup_platform(hass, config, add_devices, discovery_info=None):
+async def async_setup_platform(
+        hass, config, async_add_entities, discovery_info=None):
   """Adds sensor platform to the list of platforms."""
-  add_devices([OuraSleepSensor(config, hass)], True)
+  async_add_entities([OuraSleepSensor(config, hass)], True)
 
 
 def _seconds_to_hours(time_in_seconds):
@@ -108,6 +109,7 @@ class OuraSleepSensor(entity.Entity):
     device_state_attributes: attributes of the sensor.
 
   Methods:
+    async_update: async version of update method.
     create_oauth_view: creates a view to manage OAuth setup.
     update: updates sensor data.
   """
@@ -362,3 +364,7 @@ class OuraSleepSensor(entity.Entity):
   def device_state_attributes(self):
     """Returns the sensor attributes."""
     return self._attributes
+
+  # Async wrappers.
+  async def async_update(self):
+    await self._hass.async_add_job(self.update)

--- a/custom_components/oura/views.py
+++ b/custom_components/oura/views.py
@@ -29,7 +29,7 @@ class OuraAuthCallbackView(http.HomeAssistantView):
     self._sensor = sensor
 
   @core.callback
-  def get(self, request):
+  async def get(self, request):
     """Handles Oura OAuth callbacks.
 
     Stores code from Oura API into cache token file.
@@ -44,7 +44,8 @@ class OuraAuthCallbackView(http.HomeAssistantView):
     with open(token_file_name, 'w+') as token_file:
       token_file.write(json.dumps(code_data))
 
-    self._sensor.update()  # Forces exchanging code for access token.
+    # Forces exchanging code for access token.
+    await self._sensor.async_update()
 
     return self.json_message(
         f'Oura OAuth code {code} for sensor.{sensor_name} stored in '


### PR DESCRIPTION
This is a requirement on Home-Assistant which was making the OAuth process break by throwing 500 errors. This makes the code async and fixes #7 (and potentially #6).