### PR TITLE
Update Activity to include day

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,7 +314,7 @@ This sensor supports all the following monitored attributes:
 
 For a definition of all these variables, check [Oura's API](https://cloud.ouraring.com/v2/docs#operation/daily_activity_route_daily_activity_get).
 
-By default, the following attributes are being monitored: `active_calories`, `high_activity_time`, `low_activity_time`, `medium_activity_time`, `non_wear_time`, `resting_time`, `sedentary_time`, `score`, `target_calories`, `total_calories`.
+By default, the following attributes are being monitored: `active_calories`, `high_activity_time`, `low_activity_time`, `medium_activity_time`, `non_wear_time`, `resting_time`, `sedentary_time`, `score`, `target_calories`, `total_calories`, `day`.
 
 #### Activity Sensor sample output
 

--- a/custom_components/oura/sensor_activity.py
+++ b/custom_components/oura/sensor_activity.py
@@ -22,6 +22,7 @@ _DEFAULT_MONITORED_VARIABLES = [
     'score',
     'target_calories',
     'total_calories',
+    'day',
 ]
 _SUPPORTED_MONITORED_VARIABLES = [
     'class_5_min',

--- a/custom_components/oura/sensor_activity.py
+++ b/custom_components/oura/sensor_activity.py
@@ -13,6 +13,7 @@ _DEFAULT_NAME = 'oura_activity'
 CONF_KEY_NAME = 'activity'
 _DEFAULT_MONITORED_VARIABLES = [
     'active_calories',
+    'day',
     'high_activity_time',
     'low_activity_time',
     'medium_activity_time',
@@ -22,7 +23,6 @@ _DEFAULT_MONITORED_VARIABLES = [
     'score',
     'target_calories',
     'total_calories',
-    'day',
 ]
 _SUPPORTED_MONITORED_VARIABLES = [
     'class_5_min',


### PR DESCRIPTION
This is adding the day to the Activity sensor attributes, It helps to prevent issues that I encountered from the day not showing up by default compared to other sensors. fixes #38  